### PR TITLE
Css

### DIFF
--- a/client/Components/Concerts/ConcertFriends.jsx
+++ b/client/Components/Concerts/ConcertFriends.jsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
         padding: '1rem',
         width: '7rem',
         height: '8.5rem',
-        background: theme.palette.background.default,
+        background: '#000021',
         '&:hover': {
             background: theme.palette.primary.main,
             color: theme.palette.background.default,
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
         padding: theme.spacing(2),
         width: '30vw',
         height: '30vh',
-        overflow: 'scroll',
+        overflow: 'auto',
     },
     link: {
         textDecoration: 'inherit',

--- a/client/Components/LandingPage/LandingPage.jsx
+++ b/client/Components/LandingPage/LandingPage.jsx
@@ -9,11 +9,11 @@ const useStyles = makeStyles((theme) => ({
     container: {
         width: '85%',
         textAlign: 'center',
-        paddingTop: 64,
+        paddingTop: '10vh',
         [theme.breakpoints.down('xs')]: {
             width: '85%',
         },
-        zIndex: '2',
+        zIndex: '1000',
         position: 'fixed',
         top: '50%',
         left: '50%',
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
         textDecoration: 'inherit',
     },
     text: {
-        fontSize: '12vh',
+        fontSize: '5rem',
         lineHeight: '1.15',
     },
 }));

--- a/public/style.css
+++ b/public/style.css
@@ -26,3 +26,8 @@
     background-color: #c9c9c9;
     border: 1.5px solid #838282;
 }
+
+body::-webkit-scrollbar-thumb {
+    background-color: #000021;
+    border: 1px solid #0b0c0f;
+}


### PR DESCRIPTION
- updated friend card background color so that  the dark blue matches the color  of friend cards in other components
- added a rule for the scroll bar on outer containers so the color of scrollbar thumb on the landing page, all friends, and dashboard components is dark blue and looks subtle.
  - still keeping the teal scroll thumb at the smaller divs